### PR TITLE
Shepherd checks for IANA: mention registry name, clarify 'point'

### DIFF
--- a/draft-ietf-core-coap-pubsub.md
+++ b/draft-ietf-core-coap-pubsub.md
@@ -947,7 +947,8 @@ Note to RFC Editor: Please replace all occurrences of "{{&SELF}}" with the RFC n
 
 ## Media Type Registrations {#media-type}
 
-This specification registers the "application/core-pubsub+cbor" media type for messages of the protocols defined in this document and carrying topic properties encoded in CBOR. This registration follows the procedures specified in {{BCP13}}.
+This specification registers the "application/core-pubsub+cbor" media type in the IANA Media Types registry.
+It is used for messages of the protocols defined in this document and carries topic properties encoded in CBOR. This registration follows the procedures specified in {{BCP13}}.
 
 Type name:
 : application
@@ -1055,11 +1056,11 @@ Expert reviewers should take into consideration the following points:
 
 * Clarity and correctness of registrations. Experts are expected to check the clarity of purpose and use of the requested entries. Experts need to make sure that registered topic properties are clearly defined in the corresponding specification. Properties that do not meet these objectives of clarity and completeness must not be registered.
 
-* Point squatting should be discouraged. Reviewers are encouraged to get sufficient information for registration requests to ensure that the usage is not going to duplicate one that is already registered and that the point is likely to be used in deployments. The zones tagged as "Private Use" are intended for testing purposes and closed environments. Code points in other ranges should not be assigned for testing.
+* Code point squatting should be discouraged. Reviewers are encouraged to get sufficient information for registration requests to ensure that the usage is not going to duplicate one that is already registered and that the code point is likely to be used in deployments. The zones tagged as "Private Use" are intended for testing purposes and closed environments. Code points in other ranges should not be assigned for testing.
 
-* Specifications are required for the "Standards Action With Expert Review" range of point assignment. Specifications should exist for "Specification Required" ranges, but early assignment before a specification is available is considered to be permissible. When specifications are not provided, the description provided needs to have sufficient information to identify what the point is being used for.
+* Specifications are required for the "Standards Action With Expert Review" range of code point assignment. Specifications should exist for "Specification Required" ranges, but early assignment before a specification is available is considered to be permissible. When specifications are not provided, the description provided needs to have sufficient information to identify what the code point is being used for.
 
-* Experts should take into account the expected usage of fields when approving point assignment. Documents published via Standards Action can also register points outside the Standards Action range. The length of the encoded value should be weighed against how many code points of that length are left, the size of device it will be used on, and the number of code points left that encode to that size.
+* Experts should take into account the expected usage of fields when approving a code point assignment. Documents published via Standards Action can also register code points outside the Standards Action range. The length of the encoded value should be weighed against how many code points of that length are left, the size of device it will be used on, and the number of code points left that encode to that size.
 
 --- back
 


### PR DESCRIPTION
This improves two things:

1) the name of the 'Media Types' registry is added, which was missing and is required.
2) the term 'point' is clarified to 'code point' to better refer back to BCP100 terminology
   and avoid confusion with the other use of 'point' in the same text.